### PR TITLE
Update to play 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Couchbase Plugin for Play framework 2.1
+Couchbase Plugin for Play framework 2.2
 =======================================
 
 Contents

--- a/plugin/src/main/java/org/ancelin/play2/java/couchbase/CouchbaseBucket.java
+++ b/plugin/src/main/java/org/ancelin/play2/java/couchbase/CouchbaseBucket.java
@@ -27,63 +27,63 @@ public class CouchbaseBucket {
     }
 
     public <T> Promise<Collection<T>> find(String docName, String viewName, Query query, Class<T> clazz) {
-        return new Promise<Collection<T>>(couchbase.javaFind(docName, viewName, query, clazz, client, ec));
+        return Promise.wrap(couchbase.javaFind(docName, viewName, query, clazz, client, ec));
     }
 
     public <T> Promise<Collection<T>> find(View view, Query query, Class<T> clazz) {
-        return new Promise<Collection<T>>(couchbase.javaFind(view, query, clazz, client, ec));
+        return Promise.wrap(couchbase.javaFind(view, query, clazz, client, ec));
     }
 
     public <T> Promise<Collection<Row<T>>> search(String docName, String viewName, Query query, Class<T> clazz) {
-        return new Promise<Collection<Row<T>>>(couchbase.javaFullFind(docName, viewName, query, clazz, client, ec));
+        return Promise.wrap(couchbase.javaFullFind(docName, viewName, query, clazz, client, ec));
     }
 
     public <T> Promise<Collection<Row<T>>> search(View view, Query query, Class<T> clazz) {
-        return new Promise<Collection<Row<T>>>(couchbase.javaFullFind(view, query, clazz, client, ec));
+        return Promise.wrap(couchbase.javaFullFind(view, query, clazz, client, ec));
     }
 
     public Promise<View> view(String docName, String view) {
-        return new Promise<View>(couchbase.javaView(docName, view, client, ec));
+        return Promise.wrap(couchbase.javaView(docName, view, client, ec));
     }
 
     public <T> Promise<T> get(String key, Class<T> clazz) {
-        return new Promise<T>(couchbase.javaGet(key, clazz, client, ec));
+        return Promise.wrap(couchbase.javaGet(key, clazz, client, ec));
     }
 
     public <T> Promise<F.Option<T>> getOpt(String key, Class<T> clazz) {
-        return new Promise<F.Option<T>>(couchbase.javaOptGet(key, clazz, client, ec));
+        return Promise.wrap(couchbase.javaOptGet(key, clazz, client, ec));
     }
 
     public Promise<OperationStatus> incr(String key, Integer of) {
-        return new Promise<OperationStatus>(couchbase.incr(key, of, client, ec));
+        return Promise.wrap(couchbase.incr(key, of, client, ec));
     }
 
     public Promise<OperationStatus> incr(String key, Long of) {
-        return new Promise<OperationStatus>(couchbase.incr(key, of, client, ec));
+        return Promise.wrap(couchbase.incr(key, of, client, ec));
     }
 
     public Promise<OperationStatus> decr(String key, Integer of) {
-        return new Promise<OperationStatus>(couchbase.decr(key, of, client, ec));
+        return Promise.wrap(couchbase.decr(key, of, client, ec));
     }
 
     public Promise<OperationStatus> decr(String key, Long of) {
-        return new Promise<OperationStatus>(couchbase.decr(key, of, client, ec));
+        return Promise.wrap(couchbase.decr(key, of, client, ec));
     }
 
     public Promise<Integer> incrAndGet(String key, Integer of) {
-        return new Promise<Integer>(couchbase.asJavaInt(couchbase.incrAndGet(key, of, client, ec), ec));
+        return Promise.wrap(couchbase.asJavaInt(couchbase.incrAndGet(key, of, client, ec), ec));
     }
 
     public Promise<Long> incrAndGet(String key, Long of) {
-        return new Promise<Long>(couchbase.asJavaLong(couchbase.incrAndGet(key, of, client, ec), ec));
+        return Promise.wrap(couchbase.asJavaLong(couchbase.incrAndGet(key, of, client, ec), ec));
     }
 
     public Promise<Integer> decrAndGet(String key, Integer of) {
-        return new Promise<Integer>(couchbase.asJavaInt(couchbase.decrAndGet(key, of, client, ec), ec));
+        return Promise.wrap(couchbase.asJavaInt(couchbase.decrAndGet(key, of, client, ec), ec));
     }
 
     public Promise<Long> decrAndGet(String key, Long of) {
-        return new Promise<Long>(couchbase.asJavaLong(couchbase.decrAndGet(key, of, client, ec), ec));
+        return Promise.wrap(couchbase.asJavaLong(couchbase.decrAndGet(key, of, client, ec), ec));
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -91,35 +91,35 @@ public class CouchbaseBucket {
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     public <T> Promise<OperationStatus> set(String key, T value) {
-        return new Promise<OperationStatus>(couchbase.javaSet(key, -1, Json.stringify(Json.toJson(value)), PersistTo.ZERO, ReplicateTo.ZERO, client, ec));
+        return Promise.wrap(couchbase.javaSet(key, -1, Json.stringify(Json.toJson(value)), PersistTo.ZERO, ReplicateTo.ZERO, client, ec));
     }
 
     public <T> Promise<OperationStatus> set(String key, int exp, T value) {
-        return new Promise<OperationStatus>(couchbase.javaSet(key, exp, Json.stringify(Json.toJson(value)), PersistTo.ZERO, ReplicateTo.ZERO, client, ec));
+        return Promise.wrap(couchbase.javaSet(key, exp, Json.stringify(Json.toJson(value)), PersistTo.ZERO, ReplicateTo.ZERO, client, ec));
     }
 
     public <T> Promise<OperationStatus> set(String key, int exp, T value, ReplicateTo replicateTo) {
-        return new Promise<OperationStatus>(couchbase.javaSet(key, exp, Json.stringify(Json.toJson(value)), PersistTo.ZERO, replicateTo, client, ec));
+        return Promise.wrap(couchbase.javaSet(key, exp, Json.stringify(Json.toJson(value)), PersistTo.ZERO, replicateTo, client, ec));
     }
 
     public <T> Promise<OperationStatus> set(String key, T value, ReplicateTo replicateTo) {
-        return new Promise<OperationStatus>(couchbase.javaSet(key, -1, Json.stringify(Json.toJson(value)), PersistTo.ZERO, replicateTo, client, ec));
+        return Promise.wrap(couchbase.javaSet(key, -1, Json.stringify(Json.toJson(value)), PersistTo.ZERO, replicateTo, client, ec));
     }
 
     public <T> Promise<OperationStatus> set(String key, int exp, T value, PersistTo persistTo) {
-        return new Promise<OperationStatus>(couchbase.javaSet(key, exp, Json.stringify(Json.toJson(value)), persistTo, ReplicateTo.ZERO, client, ec));
+        return Promise.wrap(couchbase.javaSet(key, exp, Json.stringify(Json.toJson(value)), persistTo, ReplicateTo.ZERO, client, ec));
     }
 
     public <T> Promise<OperationStatus> set(String key, T value, PersistTo persistTo) {
-        return new Promise<OperationStatus>(couchbase.javaSet(key, -1, Json.stringify(Json.toJson(value)), persistTo, ReplicateTo.ZERO, client, ec));
+        return Promise.wrap(couchbase.javaSet(key, -1, Json.stringify(Json.toJson(value)), persistTo, ReplicateTo.ZERO, client, ec));
     }
 
     public <T> Promise<OperationStatus> set(String key, int exp, T value, PersistTo persistTo, ReplicateTo replicateTo) {
-        return new Promise<OperationStatus>(couchbase.javaSet(key, exp, Json.stringify(Json.toJson(value)), persistTo, replicateTo, client, ec));
+        return Promise.wrap(couchbase.javaSet(key, exp, Json.stringify(Json.toJson(value)), persistTo, replicateTo, client, ec));
     }
 
     public <T> Promise<OperationStatus> set(String key, T value, PersistTo persistTo, ReplicateTo replicateTo) {
-        return new Promise<OperationStatus>(couchbase.javaSet(key, -1, Json.stringify(Json.toJson(value)), persistTo, replicateTo, client, ec));
+        return Promise.wrap(couchbase.javaSet(key, -1, Json.stringify(Json.toJson(value)), persistTo, replicateTo, client, ec));
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -127,35 +127,35 @@ public class CouchbaseBucket {
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     public <T> Promise<OperationStatus> add(String key, T value) {
-        return new Promise<OperationStatus>(couchbase.javaAdd(key, -1, Json.stringify(Json.toJson(value)), PersistTo.ZERO, ReplicateTo.ZERO, client, ec));
+        return Promise.wrap(couchbase.javaAdd(key, -1, Json.stringify(Json.toJson(value)), PersistTo.ZERO, ReplicateTo.ZERO, client, ec));
     }
 
     public <T> Promise<OperationStatus> add(String key, int exp, T value) {
-        return new Promise<OperationStatus>(couchbase.javaAdd(key, exp, Json.stringify(Json.toJson(value)), PersistTo.ZERO, ReplicateTo.ZERO, client, ec));
+        return Promise.wrap(couchbase.javaAdd(key, exp, Json.stringify(Json.toJson(value)), PersistTo.ZERO, ReplicateTo.ZERO, client, ec));
     }
 
     public <T> Promise<OperationStatus> add(String key, int exp, T value, ReplicateTo replicateTo) {
-        return new Promise<OperationStatus>(couchbase.javaAdd(key, exp, Json.stringify(Json.toJson(value)), PersistTo.ZERO, replicateTo, client, ec));
+        return Promise.wrap(couchbase.javaAdd(key, exp, Json.stringify(Json.toJson(value)), PersistTo.ZERO, replicateTo, client, ec));
     }
 
     public <T> Promise<OperationStatus> add(String key, T value, ReplicateTo replicateTo) {
-        return new Promise<OperationStatus>(couchbase.javaAdd(key, -1, Json.stringify(Json.toJson(value)), PersistTo.ZERO, replicateTo, client, ec));
+        return Promise.wrap(couchbase.javaAdd(key, -1, Json.stringify(Json.toJson(value)), PersistTo.ZERO, replicateTo, client, ec));
     }
 
     public <T> Promise<OperationStatus> add(String key, int exp, T value, PersistTo persistTo) {
-        return new Promise<OperationStatus>(couchbase.javaAdd(key, exp, Json.stringify(Json.toJson(value)), persistTo, ReplicateTo.ZERO, client, ec));
+        return Promise.wrap(couchbase.javaAdd(key, exp, Json.stringify(Json.toJson(value)), persistTo, ReplicateTo.ZERO, client, ec));
     }
 
     public <T> Promise<OperationStatus> add(String key, T value, PersistTo persistTo) {
-        return new Promise<OperationStatus>(couchbase.javaAdd(key, -1, Json.stringify(Json.toJson(value)), persistTo, ReplicateTo.ZERO, client, ec));
+        return Promise.wrap(couchbase.javaAdd(key, -1, Json.stringify(Json.toJson(value)), persistTo, ReplicateTo.ZERO, client, ec));
     }
 
     public <T> Promise<OperationStatus> add(String key, int exp, T value, PersistTo persistTo, ReplicateTo replicateTo) {
-        return new Promise<OperationStatus>(couchbase.javaAdd(key, exp, Json.stringify(Json.toJson(value)), persistTo, replicateTo, client, ec));
+        return Promise.wrap(couchbase.javaAdd(key, exp, Json.stringify(Json.toJson(value)), persistTo, replicateTo, client, ec));
     }
 
     public <T> Promise<OperationStatus> add(String key, T value, PersistTo persistTo, ReplicateTo replicateTo) {
-        return new Promise<OperationStatus>(couchbase.javaAdd(key, -1, Json.stringify(Json.toJson(value)), persistTo, replicateTo, client, ec));
+        return Promise.wrap(couchbase.javaAdd(key, -1, Json.stringify(Json.toJson(value)), persistTo, replicateTo, client, ec));
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -163,35 +163,35 @@ public class CouchbaseBucket {
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     public <T> Promise<OperationStatus> replace(String key, int exp, T value) {
-        return new Promise<OperationStatus>(couchbase.javaReplace(key, exp, Json.stringify(Json.toJson(value)), PersistTo.ZERO, ReplicateTo.ZERO, client, ec));
+        return Promise.wrap(couchbase.javaReplace(key, exp, Json.stringify(Json.toJson(value)), PersistTo.ZERO, ReplicateTo.ZERO, client, ec));
     }
 
     public <T> Promise<OperationStatus> replace(String key, int exp, T value, ReplicateTo replicateTo) {
-        return new Promise<OperationStatus>(couchbase.javaReplace(key, exp, Json.stringify(Json.toJson(value)), PersistTo.ZERO, replicateTo, client, ec));
+        return Promise.wrap(couchbase.javaReplace(key, exp, Json.stringify(Json.toJson(value)), PersistTo.ZERO, replicateTo, client, ec));
     }
 
     public <T> Promise<OperationStatus> replace(String key, T value, ReplicateTo replicateTo) {
-        return new Promise<OperationStatus>(couchbase.javaReplace(key, -1, Json.stringify(Json.toJson(value)), PersistTo.ZERO, replicateTo, client, ec));
+        return Promise.wrap(couchbase.javaReplace(key, -1, Json.stringify(Json.toJson(value)), PersistTo.ZERO, replicateTo, client, ec));
     }
 
     public <T> Promise<OperationStatus> replace(String key, int exp, T value, PersistTo persistTo) {
-        return new Promise<OperationStatus>(couchbase.javaReplace(key, exp, Json.stringify(Json.toJson(value)), persistTo, ReplicateTo.ZERO, client, ec));
+        return Promise.wrap(couchbase.javaReplace(key, exp, Json.stringify(Json.toJson(value)), persistTo, ReplicateTo.ZERO, client, ec));
     }
 
     public <T> Promise<OperationStatus> replace(String key, T value, PersistTo persistTo) {
-        return new Promise<OperationStatus>(couchbase.javaReplace(key, -1, Json.stringify(Json.toJson(value)), persistTo, ReplicateTo.ZERO, client, ec));
+        return Promise.wrap(couchbase.javaReplace(key, -1, Json.stringify(Json.toJson(value)), persistTo, ReplicateTo.ZERO, client, ec));
     }
 
     public <T> Promise<OperationStatus> replace(String key, int exp, T value, PersistTo persistTo, ReplicateTo replicateTo) {
-        return new Promise<OperationStatus>(couchbase.javaReplace(key, exp, Json.stringify(Json.toJson(value)), persistTo, replicateTo, client, ec));
+        return Promise.wrap(couchbase.javaReplace(key, exp, Json.stringify(Json.toJson(value)), persistTo, replicateTo, client, ec));
     }
 
     public <T> Promise<OperationStatus> replace(String key, T value, PersistTo persistTo, ReplicateTo replicateTo) {
-        return new Promise<OperationStatus>(couchbase.javaReplace(key, -1, Json.stringify(Json.toJson(value)), persistTo, replicateTo, client, ec));
+        return Promise.wrap(couchbase.javaReplace(key, -1, Json.stringify(Json.toJson(value)), persistTo, replicateTo, client, ec));
     }
 
     public <T> Promise<OperationStatus> replace(String key, T value) {
-        return new Promise<OperationStatus>(couchbase.javaReplace(key, -1, Json.stringify(Json.toJson(value)), PersistTo.ZERO, ReplicateTo.ZERO, client, ec));
+        return Promise.wrap(couchbase.javaReplace(key, -1, Json.stringify(Json.toJson(value)), PersistTo.ZERO, ReplicateTo.ZERO, client, ec));
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -199,19 +199,19 @@ public class CouchbaseBucket {
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     public Promise<OperationStatus> delete(String key){
-        return new Promise<OperationStatus>(couchbase.delete(key, client, ec));
+        return Promise.wrap(couchbase.delete(key, client, ec));
     }
 
     public Promise<OperationStatus> delete(String key, ReplicateTo replicateTo){
-        return new Promise<OperationStatus>(couchbase.delete(key, replicateTo, client, ec));
+        return Promise.wrap(couchbase.delete(key, replicateTo, client, ec));
     }
 
     public Promise<OperationStatus> delete(String key, PersistTo persistTo){
-        return new Promise<OperationStatus>(couchbase.delete(key, persistTo, client, ec));
+        return Promise.wrap(couchbase.delete(key, persistTo, client, ec));
     }
 
     public Promise<OperationStatus> delete(String key, PersistTo persistTo, ReplicateTo replicateTo){
-        return new Promise<OperationStatus>(couchbase.delete(key, persistTo, replicateTo, client, ec));
+        return Promise.wrap(couchbase.delete(key, persistTo, replicateTo, client, ec));
     }
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -219,10 +219,10 @@ public class CouchbaseBucket {
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     public Promise<OperationStatus> flush(int delay) {
-        return new Promise<OperationStatus>(couchbase.flush(delay, client, ec));
+        return Promise.wrap(couchbase.flush(delay, client, ec));
     }
 
     public Promise<OperationStatus> flush() {
-       return new Promise<OperationStatus>(couchbase.flush(client, ec));
+       return Promise.wrap(couchbase.flush(client, ec));
     }
 }

--- a/plugin/src/main/scala/org/ancelin/play2/couchbase/BucketAPI.scala
+++ b/plugin/src/main/scala/org/ancelin/play2/couchbase/BucketAPI.scala
@@ -89,7 +89,7 @@ trait BucketAPI {
     Couchbase.spatialView(docName, viewName)(self, ec)
   }
 
-  def designDocument(docName: String)(implicit ec: ExecutionContext): Future[DesignDocument[_]] = {
+  def designDocument(docName: String)(implicit ec: ExecutionContext): Future[DesignDocument] = {
     Couchbase.designDocument(docName)(self, ec)
   }
 
@@ -101,7 +101,7 @@ trait BucketAPI {
     Couchbase.createDesignDoc(name, value)(self, ec)
   }
 
-  def createDesignDoc(value: DesignDocument[_])(implicit ec: ExecutionContext): Future[OperationStatus] = {
+  def createDesignDoc(value: DesignDocument)(implicit ec: ExecutionContext): Future[OperationStatus] = {
     Couchbase.createDesignDoc(value)(self, ec)
   }
 

--- a/plugin/src/main/scala/org/ancelin/play2/couchbase/ClientWrapper.scala
+++ b/plugin/src/main/scala/org/ancelin/play2/couchbase/ClientWrapper.scala
@@ -1,7 +1,7 @@
 package org.ancelin.play2.couchbase
 
 import play.api.libs.json._
-import scala.concurrent.{Promise, Future, ExecutionContext}
+import scala.concurrent.{Future, ExecutionContext}
 import net.spy.memcached.ops.OperationStatus
 import com.couchbase.client.protocol.views._
 import collection.JavaConversions._
@@ -40,7 +40,7 @@ class __EnumeratorHolder[T](futureEnumerator: Future[Enumerator[T]]) {
   def enumerate: Future[Enumerator[T]] = futureEnumerator
   def enumerated(implicit ec: ExecutionContext): Enumerator[T] = {
     val (en, channel) = Concurrent.broadcast[T]
-    futureEnumerator.map(e => e(Iteratee.foreach[T](channel.push(_)).mapDone(_ => channel.eofAndEnd())))
+    futureEnumerator.map(e => e(Iteratee.foreach[T](channel.push).map(_ => channel.eofAndEnd())))
     en
   }
   def toList(implicit ec: ExecutionContext): Future[List[T]] = {
@@ -181,7 +181,7 @@ trait ClientWrapper {
     wrapJavaFutureInPureFuture( bucket.couchbaseClient.asyncGetSpatialView(docName, viewName), ec )
   }
 
-  def designDocument(docName: String)(implicit bucket: CouchbaseBucket, ec: ExecutionContext): Future[DesignDocument[_]] = {
+  def designDocument(docName: String)(implicit bucket: CouchbaseBucket, ec: ExecutionContext): Future[DesignDocument] = {
     wrapJavaFutureInPureFuture( bucket.couchbaseClient.asyncGetDesignDocument(docName), ec )
   }
 
@@ -193,7 +193,7 @@ trait ClientWrapper {
     wrapJavaFutureInFuture( bucket.couchbaseClient.asyncCreateDesignDoc(name, value), ec )
   }
 
-  def createDesignDoc(value: DesignDocument[_])(implicit bucket: CouchbaseBucket, ec: ExecutionContext): Future[OperationStatus] = {
+  def createDesignDoc(value: DesignDocument)(implicit bucket: CouchbaseBucket, ec: ExecutionContext): Future[OperationStatus] = {
     wrapJavaFutureInFuture( bucket.couchbaseClient.asyncCreateDesignDoc(value), ec )
   }
 

--- a/plugin/src/main/scala/org/ancelin/play2/couchbase/Couchbase.scala
+++ b/plugin/src/main/scala/org/ancelin/play2/couchbase/Couchbase.scala
@@ -9,9 +9,7 @@ import collection.mutable.ArrayBuffer
 import play.api.Play.current
 import scala.Some
 import scala.concurrent.ExecutionContext
-import play.api.libs.concurrent.Akka
 import akka.actor.ActorSystem
-import org.ancelin.play2.couchbase.CouchbasePlugin
 
 class CouchbaseBucket(val client: Option[CouchbaseClient], val hosts: List[String], val port: String, val base: String, val bucket: String, val pass: String, val timeout: Long) extends BucketAPI {
 
@@ -31,7 +29,7 @@ class CouchbaseBucket(val client: Option[CouchbaseClient], val hosts: List[Strin
   }*/
 
   def couchbaseClient: CouchbaseClient = {
-    client.getOrElse(throw new PlayException(s"Error with bucket ${bucket}", s"Bucket '${bucket}' is not defined or client is not connected"))
+    client.getOrElse(throw new PlayException(s"Error with bucket $bucket", s"Bucket '$bucket' is not defined or client is not connected"))
   }
 }
 

--- a/plugin/src/main/scala/org/ancelin/play2/couchbase/CouchbaseController.scala
+++ b/plugin/src/main/scala/org/ancelin/play2/couchbase/CouchbaseController.scala
@@ -3,7 +3,6 @@ package org.ancelin.play2.couchbase
 import scala.concurrent.Future
 import play.api.mvc._
 import play.api.Play.current
-import com.couchbase.client.CouchbaseClient
 
 trait CouchbaseController { self: Controller =>
 
@@ -11,39 +10,27 @@ trait CouchbaseController { self: Controller =>
   def defaultClient = defaultBucket.client
   def buckets = Couchbase.buckets
 
-  def CouchbaseAction(block: CouchbaseBucket => Future[Result]):EssentialAction = {
-    Action {
-      Async {
-        implicit val client = Couchbase.defaultBucket(current)
-        block(client)
-      }
+  def CouchbaseAction(block: CouchbaseBucket => Future[SimpleResult]) =
+    Action.async {
+      implicit val client = Couchbase.defaultBucket(current)
+      block(client)
     }
-  }
 
-  def CouchbaseAction(bucket :String)(block: CouchbaseBucket => Future[Result]):EssentialAction = {
-    Action {
-      Async {
-        implicit val client = Couchbase.bucket(bucket)(current)
-        block(client)
-      }
+  def CouchbaseAction(bucket: String)(block: CouchbaseBucket => Future[SimpleResult]) =
+    Action.async {
+      implicit val client = Couchbase.bucket(bucket)(current)
+      block(client)
     }
-  }
 
-  def CouchbaseReqAction(block: play.api.mvc.Request[AnyContent] => CouchbaseBucket => Future[Result]):EssentialAction = {
-    Action { request =>
-      Async {
-        implicit val client = Couchbase.defaultBucket(current)
-        block(request)(client)
-      }
+  def CouchbaseReqAction(block: play.api.mvc.Request[AnyContent] => CouchbaseBucket => Future[SimpleResult]) =
+    Action.async {request =>
+      implicit val client = Couchbase.defaultBucket(current)
+      block(request)(client)
     }
-  }
 
-  def CouchbaseReqAction(bucket :String)(block: play.api.mvc.Request[AnyContent] => CouchbaseBucket => Future[Result]):EssentialAction = {
-    Action { request =>
-      Async {
-        implicit val client = Couchbase.bucket(bucket)(current)
-        block(request)(client)
-      }
+  def CouchbaseReqAction(bucket :String)(block: play.api.mvc.Request[AnyContent] => CouchbaseBucket => Future[SimpleResult]) =
+    Action.async {request =>
+      implicit val client = Couchbase.bucket(bucket)(current)
+      block(request)(client)
     }
-  }
 }

--- a/plugin/src/main/scala/org/ancelin/play2/couchbase/CouchbasePlugin.scala
+++ b/plugin/src/main/scala/org/ancelin/play2/couchbase/CouchbasePlugin.scala
@@ -3,18 +3,13 @@ package org.ancelin.play2.couchbase
 import play.api.{Logger, Plugin, Application}
 import com.typesafe.config.ConfigObject
 import collection.JavaConversions._
-import org.ancelin.play2.couchbase.{Couchbase, CouchbaseBucket}
 
 class CouchbasePlugin(implicit app: Application) extends Plugin {
   val logger = Logger("CouchbasePlugin")
   var buckets: Map[String, CouchbaseBucket] = Map[String, CouchbaseBucket]()
   override def onStart {
     play.api.Play.configuration.getObjectList("couchbase.buckets").map { configs =>
-      if (configs.size() == 1) {
-        connectDefault(configs.head)
-      } else {
-        connectAll(configs)
-      }
+      configs.foreach(connect)
       configs
     }.getOrElse {
       logger.info(s"Connection to default CouchBase ...")
@@ -22,7 +17,7 @@ class CouchbasePlugin(implicit app: Application) extends Plugin {
       buckets = buckets + (cl.bucket -> cl)
     }
   }
-  def connectDefault(config: ConfigObject) {
+  private def connect(config: ConfigObject) {
     val bucket = config.get("bucket").unwrapped().asInstanceOf[String]
     val hosts = config.get("host").unwrapped() match {
       case s: String => List(s)
@@ -32,25 +27,9 @@ class CouchbasePlugin(implicit app: Application) extends Plugin {
     val base = config.get("base").unwrapped().asInstanceOf[String]
     val pass = config.get("pass").unwrapped().asInstanceOf[String]
     val timeout = config.get("timeout").unwrapped().asInstanceOf[String].toLong
-    logger.info(s"Connection to default CouchBase bucket '$bucket' ...")
-    val cl: CouchbaseBucket = Couchbase(hosts.toList, port, base, bucket, pass, timeout).connect()
-    buckets = buckets + (cl.bucket -> cl)
-  }
-  def connectAll(configs: java.util.List[_<:ConfigObject]) {
-    configs.foreach { config =>
-      val bucket = config.get("bucket").unwrapped().asInstanceOf[String]
-      val hosts = config.get("host").unwrapped() match {
-        case s: String => List(s)
-        case a: java.util.ArrayList[String] => a.toList
-      }
-      val port = config.get("port").unwrapped().asInstanceOf[String]
-      val base = config.get("base").unwrapped().asInstanceOf[String]
-      val pass = config.get("pass").unwrapped().asInstanceOf[String]
-      val timeout = config.get("timeout").unwrapped().asInstanceOf[String].toLong
-      val couchbase: CouchbaseBucket = Couchbase(hosts.toList, port, base, bucket, pass, timeout)
-      logger.info(s"Connection to bucket $bucket ...")
-      buckets = buckets + (bucket -> couchbase.connect())
-    }
+    val couchbase: CouchbaseBucket = Couchbase(hosts.toList, port, base, bucket, pass, timeout)
+    logger.info(s"Connection to bucket $bucket ...")
+    buckets = buckets + (bucket -> couchbase.connect())
   }
   override def onStop {
     logger.info("Couchbase shutdown")

--- a/plugin/src/main/scala/org/ancelin/play2/couchbase/plugins/CouchbaseCachePlugin.scala
+++ b/plugin/src/main/scala/org/ancelin/play2/couchbase/plugins/CouchbaseCachePlugin.scala
@@ -1,7 +1,7 @@
 package org.ancelin.play2.couchbase.plugins
 
 import play.api.cache.{CacheAPI, CachePlugin}
-import play.api.{PlayException, Logger, Plugin, Application}
+import play.api.{PlayException, Application}
 import java.util.concurrent.TimeUnit
 import net.spy.memcached.transcoders.{Transcoder, SerializingTranscoder}
 import java.io.{ObjectOutputStream, ByteArrayOutputStream, ObjectStreamClass}
@@ -17,7 +17,7 @@ class CouchbaseCachePlugin(app: Application) extends CachePlugin {
       override protected def deserialize(data: Array[Byte]): java.lang.Object = {
         new java.io.ObjectInputStream(new java.io.ByteArrayInputStream(data)) {
           override protected def resolveClass(desc: ObjectStreamClass) = {
-            Class.forName(desc.getName(), false, play.api.Play.current.classloader)
+            Class.forName(desc.getName, false, play.api.Play.current.classloader)
           }
         }.readObject()
       }
@@ -25,7 +25,7 @@ class CouchbaseCachePlugin(app: Application) extends CachePlugin {
       override protected def serialize(obj: java.lang.Object) = {
         val bos: ByteArrayOutputStream = new ByteArrayOutputStream()
         new ObjectOutputStream(bos).writeObject(obj)
-        bos.toByteArray()
+        bos.toByteArray
       }
     }
 

--- a/plugin/src/main/scala/org/ancelin/play2/couchbase/plugins/CouchbaseEvolutions.scala
+++ b/plugin/src/main/scala/org/ancelin/play2/couchbase/plugins/CouchbaseEvolutions.scala
@@ -107,7 +107,7 @@ class CouchbaseEvolutionsPlugin(app: Application) extends Plugin {
               app.mode match {
                 case Mode.Test => perform(documents, synchronise)
                 case Mode.Dev if applyEvolutions => perform(documents, synchronise)
-                case Mode.Prod if applyEvolutions => perform(documents, synchronise, false)
+                case Mode.Prod if applyEvolutions => perform(documents, synchronise, dev = false)
                 case Mode.Prod => {
                   Logger("play").warn(s"Your production bucket $name needs couchbase design documents evolution!\n\n")
                   Logger("play").warn(s"Run with -Dcouchbase.evolutions.$name.apply=true if you want to run them automatically (be careful)")

--- a/plugin/src/main/scala/org/ancelin/play2/couchbase/plugins/CouchbaseFixturesPlugin.scala
+++ b/plugin/src/main/scala/org/ancelin/play2/couchbase/plugins/CouchbaseFixturesPlugin.scala
@@ -20,7 +20,7 @@ class CouchbaseFixturesPlugin(app: Application) extends Plugin {
   def insertDocuments(id: String, documents: Iterator[Seq[JsObject]], bucket: CouchbaseBucket) = {
     documents.map { seq =>
       seq.map { doc =>
-        (doc \ id) match {
+        doc \ id match {
           case actualId: JsString => Couchbase.set(actualId.value, doc)(bucket, CouchbaseRWImplicits.jsObjectToDocumentWriter, ec)
           case _ => throw new PlayException("Error while inserting fixture", s"Member named $id not found in object")
         }

--- a/plugin/src/main/scala/org/ancelin/play2/couchbase/plugins/CouchbaseN1QLPlugin.scala
+++ b/plugin/src/main/scala/org/ancelin/play2/couchbase/plugins/CouchbaseN1QLPlugin.scala
@@ -18,7 +18,7 @@ class CouchbaseN1QLPlugin(app: Application) extends Plugin {
   override def onStart {
     val host = Play.configuration.getString("couchbase.n1ql.host").getOrElse(throw new PlayException("Cannot find N1QL host", "Cannot find N1QL host in couchbase.n1ql conf."))
     val port = Play.configuration.getString("couchbase.n1ql.port").getOrElse(throw new PlayException("Cannot find N1QL port", "Cannot find N1QL port in couchbase.n1ql conf."))
-    queryBase = Some(WS.url(s"http://${host}:${port}/query"))
+    queryBase = Some(WS.url(s"http://$host:$port/query"))
   }
 }
 
@@ -52,11 +52,11 @@ class N1QLQuery(query: String, base: WSRequestHolder) {
   }
 
   def asJsonEnumerator(implicit ec: ExecutionContext): Enumerator[JsObject] = {
-    Concurrent.unicast[JsObject](onStart = c => enumerateJson(ec).map(_(Iteratee.foreach[JsObject](c.push).mapDone(_ => c.eofAndEnd()))))
+    Concurrent.unicast[JsObject](onStart = c => enumerateJson(ec).map(_(Iteratee.foreach[JsObject](c.push).map(_ => c.eofAndEnd()))))
   }
 
   def asEnumerator[T](implicit r: Reads[T], ec: ExecutionContext): Enumerator[T] = {
-    Concurrent.unicast[T](onStart = c => enumerate[T](r, ec).map(_(Iteratee.foreach[T](c.push).mapDone(_ => c.eofAndEnd()))))
+    Concurrent.unicast[T](onStart = c => enumerate[T](r, ec).map(_(Iteratee.foreach[T](c.push).map(_ => c.eofAndEnd()))))
   }
 
   def toJsArray(implicit ec: ExecutionContext): Future[JsArray] = {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,9 +6,9 @@ object ApplicationBuild extends Build {
 
   val appName         = "play2-couchbase"
   val appVersion      = "0.1-SNAPSHOT"
-  val appScalaVersion = "2.10.0"
+  val appScalaVersion = "2.10.2"
   val appScalaBinaryVersion = "2.10"
-  val appScalaCrossVersions = Seq("2.10.0")
+  val appScalaCrossVersions = Seq("2.10.2")
 
   val local: Project.Initialize[Option[sbt.Resolver]] = version { (version: String) =>
     val localPublishRepo = "./repository"
@@ -36,8 +36,8 @@ object ApplicationBuild extends Build {
     .settings(
       resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
       resolvers += "Spy Repository" at "http://files.couchbase.com/maven2",
-      libraryDependencies += "couchbase" % "couchbase-client" % "1.1.6",
-      libraryDependencies += "play" %% "play" % "2.1.0" % "provided",
+      libraryDependencies += "couchbase" % "couchbase-client" % "1.1.9",
+      libraryDependencies += "com.typesafe.play" %% "play" % "2.2.0" % "provided",
       organization := "org.ancelin.play2.couchbase",
       version := appVersion,
       publishTo <<= local,
@@ -109,7 +109,7 @@ object ApplicationBuild extends Build {
       parallelExecution in Test := false,
       publishLocal := {},
       publish := {},
-      libraryDependencies += "play" %% "play-java" % "2.1.0" % "provided"
+      libraryDependencies += "com.typesafe.play" %% "play-java" % "2.2.0" % "provided"
     ).dependsOn(plugin)
 
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.2
+sbt.version=0.13.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,8 +6,6 @@ logLevel := Level.Warn
 // The Typesafe repository
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("play" % "sbt-plugin" % "2.1.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.0")
 
-resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
-
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.3.0-SNAPSHOT")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")

--- a/samples/scala/dummy/build.sbt
+++ b/samples/scala/dummy/build.sbt
@@ -1,4 +1,4 @@
-import PlayProject._
+import play.Project._
 
 name := "play2-couchbase-sample"
 


### PR DESCRIPTION
Because play 2.2.0 GA is released & play2-couchbase is still in pre-alpha stage. So I think we should use play 2.2.

TODO: I think we should split to several sbt project.
Ex, CouchbaseCachePlugin should be in a separate project (similar to the play-cache plugin in the framework. @see https://github.com/playframework/playframework/blob/master/framework/project/Build.scala)
